### PR TITLE
fix: 删除namespaced字段

### DIFF
--- a/src/store/modules/NumFactory/index.ts
+++ b/src/store/modules/NumFactory/index.ts
@@ -11,7 +11,6 @@ import RootStateTypes from '../../interface';
 
 // Create a new store Modules.
 const numFactoryModule: Module<NumFactoryStareTypes, RootStateTypes> = {
-  namespaced: process.env.NODE_ENV !== 'production',
   state: {
     name: 'numFactory-module',
     count: 1


### PR DESCRIPTION
1. 去除vuex namespaced限制，在任何环境调用非state方法都无需加入命名空间